### PR TITLE
Updating pipfiles to use any python3 version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,4 +17,4 @@ birdy = "*"
 
 [requires]
 
-python_version = "3.5"
+python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,24 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8eccc97f72eb4980133907c5b7287427fe991032fabbb4ce36380e5783019dae"
+            "sha256": "1f21540094ec458b71a950f6c26b5032de53ef5d28cc4468f1872d91e083f9b9"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.5.2",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.13.0-32-generic",
+            "platform_system": "Linux",
+            "platform_version": "#35~16.04.1-Ubuntu SMP Thu Jan 25 10:13:43 UTC 2018",
+            "python_full_version": "3.5.2",
+            "python_version": "3.5",
+            "sys_platform": "linux"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3"
+            "python_version": "3.5"
         },
         "sources": [
             {
@@ -20,7 +33,6 @@
             "hashes": [
                 "sha256:2ef73fb80714e10d67d46676a84416dd05c60e10dad407f051822fb83a6895e2"
             ],
-            "index": "pypi",
             "version": "==0.3.2"
         },
         "certifi": {
@@ -32,8 +44,8 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
         },
@@ -45,8 +57,8 @@
         },
         "idna": {
             "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
             ],
             "version": "==2.6"
         },
@@ -61,7 +73,6 @@
                 "sha256:0c7720b2fffe488326b5faf66429b15cfd0cadb38200d20d1ae539f2eae49e4a",
                 "sha256:a9f2bd038a05ba384fa03e39949d1445349771ce7897aeb3c6d8774beba08185"
             ],
-            "index": "pypi",
             "version": "==3.3"
         },
         "requests": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,24 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1f21540094ec458b71a950f6c26b5032de53ef5d28cc4468f1872d91e083f9b9"
-        },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.5.2",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "4.13.0-32-generic",
-            "platform_system": "Linux",
-            "platform_version": "#35~16.04.1-Ubuntu SMP Thu Jan 25 10:13:43 UTC 2018",
-            "python_full_version": "3.5.2",
-            "python_version": "3.5",
-            "sys_platform": "linux"
+            "sha256": "8eccc97f72eb4980133907c5b7287427fe991032fabbb4ce36380e5783019dae"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.5"
+            "python_version": "3"
         },
         "sources": [
             {
@@ -33,6 +20,7 @@
             "hashes": [
                 "sha256:2ef73fb80714e10d67d46676a84416dd05c60e10dad407f051822fb83a6895e2"
             ],
+            "index": "pypi",
             "version": "==0.3.2"
         },
         "certifi": {
@@ -44,8 +32,8 @@
         },
         "chardet": {
             "hashes": [
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
         },
@@ -57,8 +45,8 @@
         },
         "idna": {
             "hashes": [
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
             ],
             "version": "==2.6"
         },
@@ -73,6 +61,7 @@
                 "sha256:0c7720b2fffe488326b5faf66429b15cfd0cadb38200d20d1ae539f2eae49e4a",
                 "sha256:a9f2bd038a05ba384fa03e39949d1445349771ce7897aeb3c6d8774beba08185"
             ],
+            "index": "pypi",
             "version": "==3.3"
         },
         "requests": {


### PR DESCRIPTION
When used the commands specified in readme it keeps popping up the warning - "Python 3.5 not found"
I changed the python version from 3.5 to 3 so that it uses any python3 It then also updated the piplock file.
This fixes issue #6 